### PR TITLE
[CHORE] 로컬 개발 환경 docker-compose 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 
-.env
+.env*

--- a/podolab-api/docker-compose.local.yml
+++ b/podolab-api/docker-compose.local.yml
@@ -1,0 +1,26 @@
+services:
+  api-server:
+    build: .
+    ports:
+      - 8080:8080
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+  mysql:
+    image: mysql
+    container_name: podolab-mysql
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: podolab
+    volumes:
+      - mysql-data:/var/lib/mysql # Named Volume 방식
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping"]
+      interval: 5s
+      retries: 10
+
+volumes:
+  mysql-data:

--- a/podolab-api/docker-compose.prod.yml
+++ b/podolab-api/docker-compose.prod.yml
@@ -1,0 +1,5 @@
+services:
+  api-server:
+    image: 782595374275.dkr.ecr.ap-northeast-2.amazonaws.com/podolab-api-server
+    ports:
+      - 80:8080

--- a/podolab-api/docker-compose.yml
+++ b/podolab-api/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   api-server:
-    image: 782595374275.dkr.ecr.ap-northeast-2.amazonaws.com/podolab-api-server
     container_name: podolab-api-server
-    ports:
-      - 80:8080
     environment:
       SPRING_DATASOURCE_URL: ${DB_URL}
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}

--- a/podolab-api/start-local.sh
+++ b/podolab-api/start-local.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d

--- a/podolab-api/stop-local.sh
+++ b/podolab-api/stop-local.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml down


### PR DESCRIPTION
<!-- PR 제목 예시: [FEAT] 좌석 예약 API 구현 -->

## 🎯 작업 내용
로컬 개발 환경과 EC2 배포 환경에서 사용하는 DB가 다르기 때문에
docker-compose 설정을 환경별로 분리했습니다.

EC2 환경에서는 RDS를 사용하고 있지만
로컬에서 docker-compose 실행 시에는 RDS 퍼블릭 액세스 차단으로 DB 연결이 어려웠습니다.

그래서 로컬 개발 환경에서는 MySQL 컨테이너를 사용하고
EC2 배포 환경에서는 RDS를 사용하는 방식으로 환경을 분리했습니다.

---
## 📝 주요 변경사항

### Docker 환경 분리

docker-compose 설정을 역할별로 분리했습니다.

- `docker-compose.yml` : 공통 설정
- `docker-compose.local.yml` : 로컬 개발 환경 (MySQL 컨테이너 포함)
- `docker-compose.prod.yml` : EC2 배포 환경 (RDS 사용)

---

### 로컬 개발용 MySQL 컨테이너 추가

로컬에서 RDS에 접근할 수 없기 때문에
MySQL 컨테이너를 추가해 로컬 DB 환경을 구성했습니다.

`depends_on`과 `health_check`를 설정해
MySQL 컨테이너가 준비된 이후 애플리케이션이 실행되도록 구성했습니다.

---

### 로컬 실행 스크립트 추가

로컬 개발 환경에서 docker compose 명령어를 매번 입력하지 않도록
실행 스크립트를 추가했습니다

- `start-local.sh`
- `stop-local.sh`

---

## 🧪 테스트 결과

- MySQL 컨테이너 정상 실행 및 healthcheck 통과
- api-server 컨테이너 정상 실행
- 애플리케이션 DB 연결 확인
- stop-local.sh 실행 시 컨테이너 및 네트워크 정상 종료

---

## 📸 스크린샷 / 로그 

<img width="370" height="159" alt="image" src="https://github.com/user-attachments/assets/0d04d384-3dd1-4c2b-b726-b2a2236c69ee" />
<img width="1464" height="221" alt="image" src="https://github.com/user-attachments/assets/3eeed9bf-2855-45ab-9aee-9f22ba24ca66" />


---

## 🔗 관련 이슈

- #5 