### PR TITLE
[CHORE] GitHub Actions CI/CD 파이프라인 구성

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,71 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+  S3_BUCKET: ${{ vars.S3_BUCKET }}
+  CODEDEPLOY_APPLICATION: ${{ vars.CODEDEPLOY_APPLICATION }}
+  CODEDEPLOY_DEPLOYMENT_GROUP: ${{ vars.CODEDEPLOY_DEPLOYMENT_GROUP }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: AWS 자격 증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
+      - name: ECR 로그인
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Docker 이미지 빌드
+        run: |
+          docker build --platform linux/amd64 -t $ECR_REPOSITORY ./podolab-api
+
+      - name: ECR 이미지 태그 변경 및 푸시
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker tag $ECR_REPOSITORY:latest $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: 배포 파일 준비
+        run: |
+          mkdir -p deploy/scripts
+          cp podolab-api/appspec.yml deploy/
+          cp podolab-api/docker-compose.yml deploy/
+          cp podolab-api/docker-compose.prod.yml deploy/
+          cp podolab-api/scripts/deploy.sh deploy/scripts/
+          cp podolab-api/scripts/cleanup.sh deploy/scripts/
+
+      - name: 배포 파일 압축
+        run: |
+          cd deploy
+          zip -r deploy.zip .
+
+      - name: S3 업로드
+        run: |
+          aws s3 cp deploy/deploy.zip s3://$S3_BUCKET/deploy.zip
+
+      - name: CodeDeploy 배포 실행
+        run: |
+          aws deploy create-deployment \
+            --application-name $CODEDEPLOY_APPLICATION \
+            --deployment-group-name $CODEDEPLOY_DEPLOYMENT_GROUP \
+            --s3-location bucket=$S3_BUCKET,key=deploy.zip,bundleType=zip

--- a/podolab-api/appspec.yml
+++ b/podolab-api/appspec.yml
@@ -1,0 +1,24 @@
+version: 0.0
+os: linux
+
+files: # GitHub Actions나 CodeDeploy가 전달한 배포 파일을 EC2의 /home/ubuntu/api-server 아래에 복사
+  - source: /
+    destination: /home/ubuntu/api-server
+
+# EC2 구조
+#  /home/ubuntu/api-server
+#  ├── appspec.yml
+#  ├── docker-compose.yml
+#  ├── docker-compose.prod.yml
+#  ├── scripts
+
+hooks:
+  ApplicationStop: # 기존 컨테이너 정리
+    - location: scripts/cleanup.sh
+      timeout: 300
+      runas: ubuntu
+
+  AfterInstall: # 파일 복사 끝난 뒤 배포 실행
+    - location: scripts/deploy.sh
+      timeout: 300
+      runas: ubuntu

--- a/podolab-api/scripts/cleanup.sh
+++ b/podolab-api/scripts/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /home/ubuntu/api-server || exit 1
+
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down || true

--- a/podolab-api/scripts/deploy.sh
+++ b/podolab-api/scripts/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd /home/ubuntu/api-server || exit 1
+
+aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 782595374275.dkr.ecr.ap-northeast-2.amazonaws.com
+
+docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## 🎯 작업 내용
수동으로 진행하던 Docker 기반 배포 과정을 자동화했습니다.

GitHub main 브랜치에 push 또는 merge 시
전체 배포 과정이 자동으로 실행되도록 CI/CD 파이프라인을 구성했습니다.

<br>

## 📝 주요 변경사항

### GitHub Actions 워크플로우 작성
- `deploy-api.yml` 작성
- main 브랜치 push 또는 merge 시 자동 배포 실행되도록 설정

### Docker 이미지 빌드 / ECR 푸시 자동화
- GitHub Actions에서 Docker 이미지 빌드
- ECR 로그인 후 최신 이미지(`latest`) 푸시

### CodeDeploy 기반 배포 구성
- 배포에 필요한 파일(appspec, compose, 스크립트)만 zip으로 묶어서 S3 업로드
- CodeDeploy에서 해당 파일을 EC2로 전달하고 배포 수행하도록 설정

### 배포 관련 파일 추가
- `appspec.yml` 
- `deploy.sh`, `cleanup.sh` 
- `docker-compose.yml`, `docker-compose.prod.yml` 

<br>

## 💭 구현 과정 / 트러블슈팅

배포를 자동화하는 방식에는 SSH로 EC2에 직접 접속해 배포 명령을 실행하는 방식도 있었습니다.

AWS에서 배포가 이루어지는 흐름을 이해하는 데 초점을 맞춰 가 어떤 흐름으로 이루어지는지 이해하면서 구성하려고 했고, 아래 이유로 CodeDeploy를 선택했습니다.

- 배포 이력과 로그 확인 가능
- 배포 실패 시 롤백 지원
- 이후 서버가 여러 대로 늘어나는 경우에도 구조 유지 가능
- 이전에 한 번 사용해본 경험이 있어, 이번에는 Docker 환경으로 적용

현재는 단일 EC2 환경이기 때문에 in-place 방식으로 구성했고
블루/그린 배포와 무중단 배포는 이후 개선할 예정입니다.

### 배포 흐름
1. main 브랜치에 코드 push 또는 merge
2. GitHub Actions 실행
3. 도커 이미지 빌드 / ECR에 푸시
4. 배포 파일(appspec, compose 파일, 스크립트)을 zip으로 묶어 S3 업로드
5. CodeDeploy에 배포 요청
6. EC2의 CodeDeploy Agent가 S3에서 배포 파일을 다운로드
7. appspec.yml 기준으로 스크립트 실행 

<br>

## 🧠 배운 점

### 1. CodeDeploy와 CodeDeploy Agent의 차이
CodeDeploy는 배포를 관리하는 서비스이고
EC2 내부의 CodeDeploy Agent가 배포 명령을 받아 실제 배포를 수행한다는 점을 이해했습니다.

### 2. AppSpec 파일의 역할
appspec.yml은 CodeDeploy Agent가 배포 시 
파일 복사 경로와 실행할 스크립트를 정의하는 기준이 된다는 점을 알게 되었습니다.

### 3. IAM Role의 역할

- `CodeDeployServiceRole`: CodeDeploy 서비스가 deployment를 생성하고 관리할 때 필요
- `EC2CodeDeployRole`: EC2에서 CodeDeploy Agent가 배포를 수행하고 ECR 이미지 pull 등 AWS 리소스에 접근할 때 필요

### 4. EC2에 복사되는 파일 

처음에는 도커 이미지로 컨테이너를 실행하기 위한 docker-compose 파일만 EC2에 있으면 된다고 생각했지만, 애플리케이션 실행뿐 아니라 배포 과정을 제어하기 위한 파일들도 함께 필요하다는 것을 알게되었습니다.

CodeDeploy를 통해 배포가 시작되면 EC2 내부의 CodeDeploy Agent가 S3에서 배포 파일을 받고, 아래 파일들을 `/home/ubuntu/api-server` 경로로 복사합니다.

- `appspec.yml`
- `docker-compose.yml`
- `docker-compose.prod.yml`
- `scripts/deploy.sh`
- `scripts/cleanup.sh`

이후 CodeDeploy Agent는 appspec.yml을 기준으로 배포 단계를 수행하고
정의된 스크립트를 실행해 애플리케이션을 구동합니다.

- 애플리케이션 실행: ECR의 도커 이미지
- 배포 흐름 제어: CodeDeploy Agent + appspec.yml + 배포 스크립트

<br>

## 📌 아직 확인이 필요한 내용

- main 머지 이후 실제 자동 배포 동작
- CodeDeploy 배포 로그 확인
- EC2 반영 및 서비스 정상 동작 여부

<br>

## 🔗 관련 이슈
- #4 

<br>

## 📚 참고 자료 
AWS 공식 문서
- [What is CodeDeploy?](https://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html?utm_source=chatgpt.com)
- [AppSpec 'hooks' section](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html?utm_source=chatgpt.com)
- [Working with the CodeDeploy agent](https://docs.aws.amazon.com/codedeploy/latest/userguide/codedeploy-agent.html?utm_source=chatgpt.com)