### PR TITLE
[FIX] Gradle 빌드 단계 추가

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -24,6 +24,20 @@ jobs:
       - name: 코드 가져오기
         uses: actions/checkout@v4
 
+      - name: JDK 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Gradle 실행 권한 부여
+        working-directory: ./podolab-api
+        run: chmod +x ./gradlew
+
+      - name: 애플리케이션 빌드
+        working-directory: ./podolab-api
+        run: ./gradlew clean build
+
       - name: AWS 자격 증명 설정
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## 🎯 작업 내용

GitHub Actions에서 Docker 이미지 빌드가 실패하던 문제를 수정했습니다.

<br>

## 📝 주요 변경사항

- Docker build 이전에 Gradle 빌드 단계를 추가
- CI 환경에서 jar 파일이 생성되지 않아 발생하던 Docker build 오류 해결

<br>

## 💭 구현 과정 / 트러블슈팅
Dockerfile에서는 `build/libs` 경로의 jar 파일을 COPY하도록 되어 있었지만,  
GitHub Actions에서는 Gradle 빌드 단계가 없어 jar 파일이 없는 상태에서 Docker build가 실행되고 있었습니다.

로컬에서는 사전에 빌드를 해둔 상태라 문제가 없었지만,  
CI 환경은 매번 초기 상태에서 실행되기 때문에 동일한 설정으로는 오류가 발생했습니다.

<br>

## 🧠 배운 점 / 개선 아이디어

- CI 환경은 로컬과 달리 매번 초기 상태에서 실행되기 때문에, 필요한 빌드 산출물은 workflow에서 직접 생성해야 한다는 점을 알게 되었습니다.
- Docker build 시점에 필요한 파일이 존재하지 않으면 COPY 단계에서 오류가 발생한다는 점을 이해했습니다.

<br>

## 🔗 관련 이슈

- #4 
- #9 