### PR TITLE
[CHORE] 프로젝트 초기 설정 / 개발 컨벤션 정의

### DIFF
--- a/podolab-api/CALUDE.md
+++ b/podolab-api/CALUDE.md
@@ -1,0 +1,69 @@
+# PodoLab API - Claude 컨텍스트
+
+## 프로젝트 개요
+티켓팅 시뮬레이션 백엔드. 좌석 예약 동시성 처리 실험이 핵심 목적.
+
+## 기술 스택
+- Java 17
+- Spring Boot 3.x
+- Spring Data JPA
+- MySQL
+- Lombok
+- Gradle
+
+## 패키지 구조
+```
+com.podolab.api.
+├── concert/       # Concert.java, ConcertRepository.java
+├── seat/          # Seat.java, SeatStatus.java, SeatRepository.java
+├── reservation/   # 핵심 도메인. Controller/Service/Repository/DTO 모두 여기
+├── user/          # User.java, UserRepository.java
+└── global/
+    ├── exception/ # BaseException, ErrorCode, GlobalExceptionHandler
+    └── response/  # ApiResponse (공통 응답 포맷)
+```
+Controller는 reservation만 존재. concert/seat/user는 엔티티와 Repository만.
+
+도메인 객체에 `@Entity`, `@Column` 등 JPA 매핑 어노테이션은 허용한다.
+단, 도메인 로직 안에서 Repository를 직접 호출하거나 EntityManager를 사용하지 않는다.
+
+## 코딩 규칙
+
+### 엔티티
+- `@Setter` 사용 금지
+- 객체 생성은 `@Builder` 사용
+- 기본 생성자는 `@NoArgsConstructor(access = AccessLevel.PROTECTED)`
+- 비즈니스 로직(상태 변경 등)은 엔티티 내부 메서드로 구현
+- JPA Auditing: `createdAt`, `updatedAt` (`@EntityListeners(AuditingEntityListener.class)`)
+
+### Lombok 허용
+- `@Getter`
+- `@Builder`
+- `@NoArgsConstructor(access = AccessLevel.PROTECTED)`
+- `@RequiredArgsConstructor`
+
+`@Setter`, `@Data`, `@AllArgsConstructor` 사용 금지.
+
+### 서비스
+- 비즈니스 로직은 Service가 아니라 도메인 엔티티 안에
+- Service는 흐름 조율만 (Repository 호출 → 도메인 메서드 호출 → 저장)
+
+### 예외처리
+- 커스텀 예외는 `BaseException` 상속
+- 에러 코드는 `ErrorCode` enum으로 관리
+- `GlobalExceptionHandler`에서 일괄 처리
+
+### DTO
+- Request: `XxxRequest`
+- Response: `XxxResponse`
+- 엔티티를 Controller 밖으로 노출하지 말 것
+
+**공통 응답**
+모든 API 응답은 `ApiResponse<T>` 포맷 사용.
+
+## 절대 하지 말 것
+- `@Setter` 사용
+- 엔티티를 Response로 직접 반환
+- 요청 없이 테스트 코드 자동 생성
+- 요청 없이 `build.gradle` 의존성 수정 (필요한 경우 목록만 알려줄 것)
+- 기존 파일 무단 삭제 또는 전면 재작성


### PR DESCRIPTION
## 🎯 작업 내용
Claude Code 기반으로 개발할 때 기준이 될 프로젝트 컨벤션과 구조를 정리했습니다.

<br>

## 📝 주요 변경사항

### CLAUDE.md 작성
- 프로젝트 개요 / 사용 기술 정리
- 도메인 기준 패키지 구조 정의
- 엔티티 / Lombok / 서비스 / 예외 처리 / DTO 규칙 정의
- AI 코드 생성 시 지켜야 할 기준과 제한 사항 정리

<br>

## 💭 구현 과정
매번 컨텍스트를 다시 설명해야 하는 번거로움을 줄이기 위해 프로젝트 루트에 CLAUDE.md를 추가했습니다.

패키지 구조는 도메인 기준으로 나누는 방식을 선택했습니다. 
레이어 중심 구조보다 도메인 응집도를 높일 수 있고, 
불필요한 복잡도를 줄이면서도 구조를 명확하게 가져갈 수 있다고 판단했습니다.

엔티티 설계나 예외 처리, DTO 사용 방식 등 프로젝트 전반에서 일관되게 유지해야 할 기준들도 함께 정리했습니다.

<br>


## 🔗 관련 이슈
- #11 