### PR TITLE
[TEST] 동시 좌석 점유 테스트 코드 작성

### DIFF
--- a/podolab-api/build.gradle
+++ b/podolab-api/build.gradle
@@ -29,12 +29,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/podolab-api/src/main/java/com/podolab/api/concert/Concert.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/Concert.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -23,15 +23,23 @@ public class Concert extends BaseEntity {
     private String title;
 
     @Column(nullable = false)
-    private LocalDateTime concertDate;
+    private LocalDate concertDate;
 
     @Column(nullable = false)
     private int totalSeats;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Concert(String title, LocalDateTime concertDate, int totalSeats) {
+    private Concert(String title, LocalDate concertDate, int totalSeats) {
         this.title = title;
         this.concertDate = concertDate;
         this.totalSeats = totalSeats;
+    }
+
+    public static Concert create(String title, LocalDate concertDate, int totalSeats) {
+        return Concert.builder()
+                .title(title)
+                .concertDate(concertDate)
+                .totalSeats(totalSeats)
+                .build();
     }
 }

--- a/podolab-api/src/main/java/com/podolab/api/concert/ConcertRepository.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/ConcertRepository.java
@@ -1,0 +1,6 @@
+package com.podolab.api.concert;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConcertRepository extends JpaRepository<Concert, Integer> {
+}

--- a/podolab-api/src/main/java/com/podolab/api/seat/Seat.java
+++ b/podolab-api/src/main/java/com/podolab/api/seat/Seat.java
@@ -31,11 +31,19 @@ public class Seat extends BaseEntity {
     @Column(nullable = false)
     private SeatStatus status;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Seat(Concert concert, int seatNumber, SeatStatus status) {
         this.concert = concert;
         this.seatNumber = seatNumber;
         this.status = status;
+    }
+
+    public static Seat create(Concert concert, int seatNumber, SeatStatus status) {
+        return Seat.builder()
+                .concert(concert)
+                .seatNumber(seatNumber)
+                .status(status)
+                .build();
     }
 
 	// 좌석 선점: 결제 페이지 진입 시 호출

--- a/podolab-api/src/main/java/com/podolab/api/seathold/SeatHoldRepository.java
+++ b/podolab-api/src/main/java/com/podolab/api/seathold/SeatHoldRepository.java
@@ -3,4 +3,5 @@ package com.podolab.api.seathold;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
+	int countBySeatId(Long seatId);
 }

--- a/podolab-api/src/main/java/com/podolab/api/user/User.java
+++ b/podolab-api/src/main/java/com/podolab/api/user/User.java
@@ -23,9 +23,16 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private User(String name, String email) {
         this.name = name;
         this.email = email;
+    }
+
+    public static User create(String name, String email) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .build();
     }
 }

--- a/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
+++ b/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
@@ -1,0 +1,109 @@
+package com.podolab.api.reservation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.podolab.api.concert.Concert;
+import com.podolab.api.concert.ConcertRepository;
+import com.podolab.api.seat.Seat;
+import com.podolab.api.seat.SeatRepository;
+import com.podolab.api.seat.SeatStatus;
+import com.podolab.api.seathold.SeatHoldRepository;
+import com.podolab.api.user.User;
+import com.podolab.api.user.UserRepository;
+
+@SpringBootTest
+class ReservationServiceTest {
+
+	@Autowired
+	private ReservationService reservationService;
+
+	@Autowired
+	private ConcertRepository concertRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private SeatRepository seatRepository;
+
+	@Autowired
+	private SeatHoldRepository seatHoldRepository;
+
+	private static final int threadCount = 10;
+
+	private Long seatId;
+	private List<Long> userIds;
+
+	@BeforeEach
+	void setUp() {
+		Concert concert = concertRepository.save(
+			Concert.create("테스트 콘서트", LocalDate.now().plusDays(7), 100)
+		);
+
+		Seat seat = seatRepository.save(
+			Seat.create(concert, 1, SeatStatus.AVAILABLE)
+		);
+		seatId = seat.getId();
+
+		userIds = new ArrayList<>();
+		for (int i = 0; i < threadCount; i++) {
+			User user = userRepository.save(User.create("유저" + (i + 1), "user" + (i + 1) + "@test.com"));
+			userIds.add(user.getId());
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		seatHoldRepository.deleteAll();
+		seatRepository.deleteAll();
+		concertRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@Test
+	void 동시에_여러명이_같은_좌석_점유_시도() throws InterruptedException {
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch startLatch = new CountDownLatch(1); // 두 스레드 동시 출발시키기 위한 카운터
+		CountDownLatch doneLatch = new CountDownLatch(threadCount); // 두 스레드가 모두 종료될 때까지 메인 스레드 대기하기 위한 카운터
+		AtomicInteger successCount = new AtomicInteger(0); // 멀티스레드 환경에서 안전하게 성공 횟수 카운트
+
+		for (int i = 0; i < threadCount; i++) {
+			long userId = userIds.get(i);
+			executor.execute(() -> {
+				try {
+					startLatch.await(); // startLatch가 0이 될 때까지 대기 (두 스레드 동시 출발하도록)
+					reservationService.hold(userId, seatId);
+					successCount.incrementAndGet(); // hold() 성공 시 카운트
+				} catch (Exception e) {
+					// hold 실패 — 정상적으로 거절된 케이스
+				} finally {
+					doneLatch.countDown(); // 스레드 종료 시 doneLatch 카운트 감소
+				}
+			});
+		}
+
+		startLatch.countDown(); // 카운트를 0으로 만들어 대기 중인 두 스레드 동시 출발
+		boolean completed = doneLatch.await(5, TimeUnit.SECONDS); // 두 스레드가 모두 종료될 때까지(doneLatch가 0이 될 때까지) 최대 5초 대기
+		executor.shutdown();
+		assertThat(completed).isTrue(); // 5초 안에 두 스레드가 정상 종료됐는지 확인
+
+		// 락이 없는 상태에서 여러 스레드가 동시에 접근하면 Race Condition이 발생한다.
+		// successCount > 1이면 동시성 문제가 재현된 것이므로 테스트 실패가 정상이다.
+		assertThat(successCount.get()).isEqualTo(1);
+	}
+}

--- a/podolab-api/src/test/resources/application.yml
+++ b/podolab-api/src/test/resources/application.yml
@@ -1,14 +1,10 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:3306/podolab?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
-    properties:
-      hibernate:
-        format_sql: true


### PR DESCRIPTION
## 🎯 작업 내용
동일한 좌석을 여러 스레드가 점유 요청시 동시성 문제가 발생하는지 검증하는 테스트 코드를 작성했습니다.

<br>

## 📝 주요 변경사항

### 테스트
- `ReservationServiceTest` - 동시 좌석 점유 시도 테스트 추가
- `Concert`, `User`, `Seat` 엔티티에 팩토리 메서드 `create()` 추가
- `test/resources/application.yml` - 테스트용 DB 설정

<br>

## 💭 구현 과정 / 배운 점

### 동시성 테스트를 위한 구성 요소

#### ExecutorService
여러 작업을 동시에 실행하기 위해 스레드 풀 기반의 ExecutorService를 사용했습니다. 
`newFixedThreadPool(n)`으로 스레드 수를 고정해 동시 요청 수를 제어했고, `execute()`로 작업을 제출한 뒤 `shutdown()`으로 풀을 종료했습니다.

#### CountDownLatch
여러 스레드가 최대한 동시에 시작하도록 만들고 모든 작업이 끝날 때까지 메인 스레드가 기다리도록 하기 위해 CountDownLatch를 사용했습니다.

- `startLatch(1)`: 모든 스레드가 준비된 뒤 동시에 출발시키기 위해 사용했습니다. 각 스레드는 `await()`에서 대기하다가 `countDown()` 호출 시 동시에 실행됩니다.
- `doneLatch(n)`: 모든 스레드의 작업이 끝날 때까지 메인 스레드가 대기하도록 했습니다. 각 스레드가 `finally`에서 `countDown()`을 호출하고, 카운트가 0이 되면 이후 검증 로직으로 넘어갑니다.

#### AtomicInteger
성공 횟수를 집계할 때 일반 `int`를 사용하면 `++` 연산이 읽기 → 더하기 → 쓰기로 나뉘어 멀티스레드 환경에서 값이 꼬일 수 있습니다.  
`AtomicInteger.incrementAndGet()`을 사용하면 연산이 하나의 작업처럼 처리되어, 동시성 환경에서도 정확한 값 집계가 가능합니다.

<br>

### 데드락 발생 원인

테스트 실행 중 데드락이 발생해 원인을 확인했습니다.

`hold()` 트랜잭션 안에서는 다음 순서로 작업이 진행됐습니다.
```sql
1. SELECT * FROM users WHERE id = ?
2. SELECT * FROM seat WHERE id = ?
3. INSERT INTO seat_hold ...   ← 외래키 검증 과정에서 부모 테이블인 seat 행에 S락 획득
4. UPDATE seat SET status = HELD ← 같은 seat 행에 X락 획득 시도
5. 커밋
```

InnoDB는 외래키 제약 조건을 확인하는 과정에서 `seat_hold`를 insert할 때 부모 테이블인 `seat` row에 공유 락(S-lock)을 획득합니다.  
공유 락은 여러 트랜잭션이 동시에 보유할 수 있지만, 이후 `seat` 상태를 변경하기 위해 필요한 배타 락(X-lock)은 해당 row에 걸린 공유 락이 모두 해제되어야만 획득할 수 있습니다.

결과적으로 여러 트랜잭션이 같은 `seat` row에 대해 공유 락을 보유한 채, 다시 배타 락 획득을 기다리는 구조가 만들어졌고 이로 인해 교착 상태가 발생했습니다.

<br>

## 🧪 테스트 결과

10개 스레드가 동시에 같은 좌석에 `hold()`를 시도했을 때 데드락이 발생했고, 데드락으로 롤백되지 않은 2개의 트랜잭션이 모두 성공해 `successCount == 2`가 됐습니다.

```
2026-03-22T12:55:56.691+09:00 ERROR [pool-2-thread-2] Deadlock found when trying to get lock; try restarting transaction
2026-03-22T12:55:56.691+09:00 ERROR [pool-2-thread-3] Deadlock found when trying to get lock; try restarting transaction
2026-03-22T12:55:56.691+09:00 ERROR [pool-2-thread-5] Deadlock found when trying to get lock; try restarting transaction
2026-03-22T12:55:56.691+09:00 ERROR [pool-2-thread-9] Deadlock found when trying to get lock; try restarting transaction
...
Expected :1
Actual   :2
```

<br>

## 🔗 관련 이슈
- #15 Close

<br>

## 📚 참고 자료
- [ExecutorService - Baeldung](https://www.baeldung.com/java-executor-service-tutorial)
- [ExecutorService - Oracle 공식 문서](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html#shutdown--)
- [CountDownLatch - Oracle 공식 문서](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CountDownLatch.html)
- [CountDownLatch - Baeldung](https://www.baeldung.com/java-countdown-latch)
- [Java 동시성 테스트 - velog](https://velog.io/@jinny-l/Java-Concurrency-Test)