### PR TITLE
[CI]  PR 테스트 워크플로우 추가 및 배포 빌드에서 테스트 제외

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: podolab
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -u root -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: 코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: JDK 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Gradle 실행 권한 부여
+        working-directory: ./podolab-api
+        run: chmod +x ./gradlew
+
+      - name: 테스트 실행
+        working-directory: ./podolab-api
+        run: ./gradlew test

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: 애플리케이션 빌드
         working-directory: ./podolab-api
-        run: ./gradlew clean build
+        run: ./gradlew clean build -x test
 
       - name: AWS 자격 증명 설정
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## 🎯 작업 내용
PR 오픈 시 테스트를 자동으로 실행하는 CI 워크플로우를 추가했습니다.

기존에는 main 브랜치에 머지된 후 테스트를 실행해서 테스트가 실패해도 이미 main에 코드가 들어간다는 문제가 있었습니다.
PR 단계에서 테스트를 실행해 문제 있는 코드가 main에 머지되는 것을 사전에 차단합니다.

<br>

## 📝 주요 변경사항

- `ci-api.yml` - PR 오픈 시 테스트 실행 워크플로우 추가
- `deploy-api.yml` - 빌드 시 테스트 스킵 (`-x test`)

<br>

## 💭 구현 과정 / 트러블슈팅

### CI/CD 분리

기존 배포 워크플로우는 테스트와 배포가 한 job에 묶여있었습니다. 이 구조에서는 테스트가 머지 이후에 실행된다는 문제가 있습니다.

CI와 CD를 분리했습니다.
- **CI** (`ci-api.yml`): PR 오픈 시 테스트 실행
- **CD** (`deploy-api.yml`): main 머지 시 빌드 + 배포

<br>

### GitHub Actions MySQL 서비스 컨테이너

`ReservationServiceTest`가 MySQL에 접근하는 통합 테스트라 CI 환경에도 MySQL이 필요합니다. `services` 블록으로 GitHub Actions 러너 위에 MySQL 컨테이너를 띄웠습니다. job이 시작될 때 자동으로 뜨고 끝나면 자동으로 꺼집니다.

<br>

## 🔗 관련 이슈
- #18