### PR TITLE
[REFACTOR] SeatStatus HELD 제거

### DIFF
--- a/podolab-api/src/main/java/com/podolab/api/global/exception/ErrorCode.java
+++ b/podolab-api/src/main/java/com/podolab/api/global/exception/ErrorCode.java
@@ -14,7 +14,6 @@ public enum ErrorCode {
 
     // Seat
     SEAT_NOT_AVAILABLE(HttpStatus.CONFLICT, "예약 가능한 좌석이 아닙니다."),
-    SEAT_NOT_HELD(HttpStatus.CONFLICT, "선점되지 않은 좌석입니다."),
     SEAT_NOT_RESERVED(HttpStatus.CONFLICT, "예약 확정된 좌석이 아닙니다."),
 
     // Hold

--- a/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
@@ -39,10 +39,8 @@ public class ReservationService {
             throw new BaseException(ErrorCode.SEAT_NOT_AVAILABLE);
         }
 
-        Seat seat = seatRepository.findByIdWithLock(seatId)
+        seatRepository.findByIdWithLock(seatId)
                 .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
-
-        seat.reserve();
 
         return seatId;
     }
@@ -61,9 +59,8 @@ public class ReservationService {
 
         redisTemplate.delete(redisKey);
 
-        Seat seat = seatRepository.findByIdWithLock(seatId)
+        seatRepository.findByIdWithLock(seatId)
                 .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
-        seat.cancelHold();
     }
 
     @Transactional

--- a/podolab-api/src/main/java/com/podolab/api/seat/Seat.java
+++ b/podolab-api/src/main/java/com/podolab/api/seat/Seat.java
@@ -46,28 +46,12 @@ public class Seat extends BaseEntity {
                 .build();
     }
 
-	// 좌석 선점: 결제 페이지 진입 시 호출
-    public void reserve() {
+	// 예약 확정: 결제 완료 시 호출
+    public void confirm() {
         if (this.status != SeatStatus.AVAILABLE) {
             throw new BaseException(ErrorCode.SEAT_NOT_AVAILABLE);
         }
-        this.status = SeatStatus.HELD;
-    }
-
-	// 예약 확정: 결제 완료 시 호출
-    public void confirm() {
-        if (this.status != SeatStatus.HELD) {
-            throw new BaseException(ErrorCode.SEAT_NOT_HELD);
-        }
         this.status = SeatStatus.RESERVED;
-    }
-
-	// 선점 취소: 결제 페이지 이탈 또는 타임아웃 시 호출
-    public void cancelHold() {
-        if (this.status != SeatStatus.HELD) {
-            throw new BaseException(ErrorCode.SEAT_NOT_HELD);
-        }
-        this.status = SeatStatus.AVAILABLE;
     }
 
 	// 예약 취소: 결제 완료 후 취소 요청 시 호출

--- a/podolab-api/src/main/java/com/podolab/api/seat/SeatStatus.java
+++ b/podolab-api/src/main/java/com/podolab/api/seat/SeatStatus.java
@@ -2,6 +2,5 @@ package com.podolab.api.seat;
 
 public enum SeatStatus {
     AVAILABLE,
-    HELD,
     RESERVED
 }


### PR DESCRIPTION
## 🎯 작업 내용
SeatHold 제거로 좌석 점유 상태를 Redis에서 관리하게 되면서 HELD 상태가 불필요해졌습니다.
사용되지 않는 HELD 상태와 관련 코드를 제거합니다.

<br>

## 📝 주요 변경사항
- `SeatStatus` - HELD 제거
- `Seat` - HELD 관련 메서드 제거 (`reserve()`, `cancelHold()`)
- `ErrorCode` - SEAT_NOT_HELD 제거

<br>

## 🔗 관련 이슈
- Close #26