### PR TITLE
[FEAT] 전체 좌석 조회 API 구현

### DIFF
--- a/podolab-api/src/main/java/com/podolab/api/concert/ConcertController.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/ConcertController.java
@@ -1,0 +1,25 @@
+package com.podolab.api.concert;
+
+import com.podolab.api.global.response.ApiResponse;
+import com.podolab.api.seat.SeatResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/concerts")
+public class ConcertController {
+
+    private final ConcertService concertService;
+
+    @GetMapping("/{concertId}/seats")
+    public ResponseEntity<ApiResponse<List<SeatResponse>>> getSeats(@PathVariable Long concertId) {
+        return ResponseEntity.ok(ApiResponse.ok(concertService.getSeats(concertId)));
+    }
+}

--- a/podolab-api/src/main/java/com/podolab/api/concert/ConcertRepository.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/ConcertRepository.java
@@ -2,5 +2,5 @@ package com.podolab.api.concert;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ConcertRepository extends JpaRepository<Concert, Integer> {
+public interface ConcertRepository extends JpaRepository<Concert, Long> {
 }

--- a/podolab-api/src/main/java/com/podolab/api/concert/ConcertService.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/ConcertService.java
@@ -1,0 +1,29 @@
+package com.podolab.api.concert;
+
+import com.podolab.api.global.exception.BaseException;
+import com.podolab.api.global.exception.ErrorCode;
+import com.podolab.api.seat.SeatRepository;
+import com.podolab.api.seat.SeatResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ConcertService {
+
+    private final ConcertRepository concertRepository;
+    private final SeatRepository seatRepository;
+
+    @Transactional(readOnly = true)
+    public List<SeatResponse> getSeats(Long concertId) {
+        if (!concertRepository.existsById(concertId)) {
+            throw new BaseException(ErrorCode.CONCERT_NOT_FOUND);
+        }
+        return seatRepository.findByConcertId(concertId).stream()
+                .map(SeatResponse::of)
+                .toList();
+    }
+}

--- a/podolab-api/src/main/java/com/podolab/api/global/exception/ErrorCode.java
+++ b/podolab-api/src/main/java/com/podolab/api/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     HOLD_USER_MISMATCH(HttpStatus.FORBIDDEN, "점유한 사용자가 아닙니다."),
 
     // Not Found
+    CONCERT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 콘서트입니다."),
     SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 좌석입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.");
 

--- a/podolab-api/src/main/java/com/podolab/api/seat/SeatRepository.java
+++ b/podolab-api/src/main/java/com/podolab/api/seat/SeatRepository.java
@@ -1,5 +1,6 @@
 package com.podolab.api.seat;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 import jakarta.persistence.LockModeType;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+	List<Seat> findByConcertId(Long concertId);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT s FROM Seat s WHERE s.id = :id")

--- a/podolab-api/src/main/java/com/podolab/api/seat/SeatResponse.java
+++ b/podolab-api/src/main/java/com/podolab/api/seat/SeatResponse.java
@@ -1,0 +1,15 @@
+package com.podolab.api.seat;
+
+public record SeatResponse(
+        Long seatId,
+        int seatNumber,
+        boolean available
+) {
+    public static SeatResponse of(Seat seat) {
+        return new SeatResponse(
+                seat.getId(),
+                seat.getSeatNumber(),
+                seat.getStatus() == SeatStatus.AVAILABLE
+        );
+    }
+}

--- a/podolab-api/src/main/resources/dummy.sql
+++ b/podolab-api/src/main/resources/dummy.sql
@@ -1,0 +1,29 @@
+-- 기존 데이터 초기화
+DELETE FROM seat;
+DELETE FROM concert;
+
+-- 콘서트 1개 삽입
+INSERT INTO concert (title, concert_date, total_seats, created_at, updated_at)
+VALUES ('PODOLAB 콘서트 2026', '2026-08-01', 10000, NOW(), NOW());
+
+-- 좌석 10000개 삽입 (seatNumber 1~10000, 전부 AVAILABLE)
+DROP PROCEDURE IF EXISTS insert_seats;
+
+DELIMITER $$
+CREATE PROCEDURE insert_seats()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    DECLARE concert_id BIGINT;
+
+SELECT id INTO concert_id FROM concert LIMIT 1;
+
+WHILE i <= 10000 DO
+        INSERT INTO seat (concert_id, seat_number, status, created_at, updated_at)
+        VALUES (concert_id, i, 'AVAILABLE', NOW(), NOW());
+        SET i = i + 1;
+END WHILE;
+END$$
+DELIMITER ;
+
+CALL insert_seats();
+DROP PROCEDURE IF EXISTS insert_seats;


### PR DESCRIPTION
## 🎯 작업 내용
콘서트 좌석 선택 화면에서 전체 좌석 목록과 예약 가능 여부를 조회하는 API를 구현했습니다.

<br>

## 📝 주요 변경사항
- `ConcertController` - GET /api/concerts/{concertId}/seats 엔드포인트 추가
- `ConcertService` - 콘서트 존재 여부 검증 후 전체 좌석 조회
- `SeatResponse` - 좌석 ID, 좌석 번호, 예약 가능 여부 반환
- `dummy.sql` - 콘서트 1개, 좌석 10000개 더미 데이터

<br>

## 💭 구현 과정
### 응답 구조
- `seatNumber`: 화면에 표시할 좌석 번호
- `seatId`: hold 요청 시 사용할 식별자
- `available`: 예약 가능 여부 (AVAILABLE이면 true)

<br>

## 💡 개선 아이디어
- 티켓팅 특성상 오픈 순간 수많은 사용자가 동시에 좌석을 조회하는데, 매 요청마다 DB 쿼리가 발생하는 구조 → 캐싱 도입으로 개선 예정 #30

<br>

## 🔗 관련 이슈
- Close #28