### PR TITLE
[REFACTOR] 좌석 전체 조회 Redis 캐싱 추가 / 실시간 hold 상태 반영

### DIFF
--- a/podolab-api/k6/seat-load-test.js
+++ b/podolab-api/k6/seat-load-test.js
@@ -1,0 +1,10 @@
+import http from 'k6/http';
+
+export const options = {
+    vus: 100,        // 동시 유저 100명
+    duration: '10s', // 10초 동안
+};
+
+export default function () {
+    http.get('http://54.116.24.182/api/concerts/1/seats');
+}

--- a/podolab-api/src/main/java/com/podolab/api/concert/ConcertService.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/ConcertService.java
@@ -30,13 +30,9 @@ public class ConcertService {
 
     @Transactional(readOnly = true)
     public List<SeatResponse> getSeats(Long concertId) {
-        if (!concertRepository.existsById(concertId)) {
-            throw new BaseException(ErrorCode.CONCERT_NOT_FOUND);
-        }
-
-        String cacheKey = SEAT_CACHE_KEY_PREFIX.formatted(concertId);
+		String cacheKey = SEAT_CACHE_KEY_PREFIX.formatted(concertId);
 		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
-        Map<String, String> cached = hashOps.entries(cacheKey);
+		Map<String, String> cached = hashOps.entries(cacheKey);
 
 		// Cache Hit
         if (!cached.isEmpty()) {
@@ -51,6 +47,10 @@ public class ConcertService {
 
 		// Cache Miss
 		// 1. DB 조회
+		if (!concertRepository.existsById(concertId)) {
+			throw new BaseException(ErrorCode.CONCERT_NOT_FOUND);
+		}
+
         List<SeatResponse> seats = seatRepository.findByConcertId(concertId).stream()
                 .map(SeatResponse::of)
                 .toList();

--- a/podolab-api/src/main/java/com/podolab/api/concert/ConcertService.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/ConcertService.java
@@ -5,25 +5,62 @@ import com.podolab.api.global.exception.ErrorCode;
 import com.podolab.api.seat.SeatRepository;
 import com.podolab.api.seat.SeatResponse;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class ConcertService {
 
+    private static final String SEAT_CACHE_KEY_PREFIX = "concerts:%d:seats";
+    private static final Duration SEAT_CACHE_TTL = Duration.ofHours(1);
+
     private final ConcertRepository concertRepository;
     private final SeatRepository seatRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional(readOnly = true)
     public List<SeatResponse> getSeats(Long concertId) {
         if (!concertRepository.existsById(concertId)) {
             throw new BaseException(ErrorCode.CONCERT_NOT_FOUND);
         }
-        return seatRepository.findByConcertId(concertId).stream()
+
+        String cacheKey = SEAT_CACHE_KEY_PREFIX.formatted(concertId);
+		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
+        Map<String, String> cached = hashOps.entries(cacheKey);
+
+		// Cache Hit
+        if (!cached.isEmpty()) {
+            return cached.entrySet().stream()
+                    .map(e -> new SeatResponse(
+                            Integer.parseInt(e.getKey()), // field = seatNumber
+                            "true".equals(e.getValue()) 		   // value = available
+                    ))
+                    .sorted(Comparator.comparingInt(SeatResponse::seatNumber))
+                    .toList();
+        }
+
+		// Cache Miss
+		// 1. DB 조회
+        List<SeatResponse> seats = seatRepository.findByConcertId(concertId).stream()
                 .map(SeatResponse::of)
                 .toList();
+
+		// 2. Redis 저장
+        Map<String, String> hashEntries = new HashMap<>();
+        seats.forEach(s -> hashEntries.put(String.valueOf(s.seatNumber()), String.valueOf(s.available())));
+        redisTemplate.opsForHash().putAll(cacheKey, hashEntries);
+        redisTemplate.expire(cacheKey, SEAT_CACHE_TTL);
+
+        return seats;
     }
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/ConfirmRequest.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ConfirmRequest.java
@@ -3,7 +3,8 @@ package com.podolab.api.reservation;
 import jakarta.validation.constraints.NotNull;
 
 public record ConfirmRequest(
-        @NotNull Long seatId,
+        @NotNull Long concertId,
+        @NotNull Integer seatNumber,
         @NotNull Long userId
 ) {
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/HoldRequest.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/HoldRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record HoldRequest(
         @NotNull Long userId,
-        @NotNull Long seatId
+        @NotNull Long concertId,
+        @NotNull Integer seatNumber
 ) {
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/HoldResponse.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/HoldResponse.java
@@ -1,9 +1,10 @@
 package com.podolab.api.reservation;
 
 public record HoldResponse(
-        Long seatId
+        Long concertId,
+        int seatNumber
 ) {
-    public static HoldResponse of(Long seatId) {
-        return new HoldResponse(seatId);
+    public static HoldResponse of(Long concertId, int seatNumber) {
+        return new HoldResponse(concertId, seatNumber);
     }
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/ReleaseRequest.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ReleaseRequest.java
@@ -3,7 +3,8 @@ package com.podolab.api.reservation;
 import jakarta.validation.constraints.NotNull;
 
 public record ReleaseRequest(
-        @NotNull Long seatId,
+        @NotNull Long concertId,
+        @NotNull Integer seatNumber,
         @NotNull Long userId
 ) {
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/ReservationController.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ReservationController.java
@@ -18,19 +18,19 @@ public class ReservationController {
 
     @PostMapping("/hold")
     public ResponseEntity<ApiResponse<HoldResponse>> hold(@RequestBody @Valid HoldRequest request) {
-        Long seatId = reservationService.hold(request.userId(), request.seatId());
-        return ResponseEntity.ok(ApiResponse.ok(HoldResponse.of(seatId)));
+        reservationService.hold(request.userId(), request.concertId(), request.seatNumber());
+        return ResponseEntity.ok(ApiResponse.ok(HoldResponse.of(request.concertId(), request.seatNumber())));
     }
 
     @PostMapping("/release")
     public ResponseEntity<ApiResponse<Void>> release(@RequestBody @Valid ReleaseRequest request) {
-        reservationService.release(request.seatId(), request.userId());
+        reservationService.release(request.concertId(), request.seatNumber(), request.userId());
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @PostMapping("/confirm")
     public ResponseEntity<ApiResponse<Void>> confirm(@RequestBody @Valid ConfirmRequest request) {
-        reservationService.confirm(request.seatId(), request.userId());
+        reservationService.confirm(request.concertId(), request.seatNumber(), request.userId());
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 public class ReservationService {
 
     private static final String SEAT_HOLD_KEY_PREFIX = "concerts:%d:seats:%d:hold";
+    private static final String SEAT_CACHE_KEY_PREFIX = "concerts:%d:seats";
     private static final Duration SEAT_HOLD_TTL = Duration.ofMinutes(5);
 
     private final SeatRepository seatRepository;
@@ -41,6 +42,8 @@ public class ReservationService {
 
         seatRepository.findByConcertIdAndSeatNumberWithLock(concertId, seatNumber)
                 .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
+
+        updateSeatCache(concertId, seatNumber, false);
     }
 
     @Transactional
@@ -59,6 +62,8 @@ public class ReservationService {
 
         seatRepository.findByConcertIdAndSeatNumberWithLock(concertId, seatNumber)
                 .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
+
+        updateSeatCache(concertId, seatNumber, true);
     }
 
     @Transactional
@@ -82,5 +87,14 @@ public class ReservationService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
         ticketRepository.save(Ticket.create(user, seat, seat.getConcert()));
+
+        updateSeatCache(concertId, seatNumber, false);
+    }
+
+    private void updateSeatCache(Long concertId, int seatNumber, boolean available) {
+        String cacheKey = SEAT_CACHE_KEY_PREFIX.formatted(concertId);
+        if (redisTemplate.hasKey(cacheKey)) {
+            redisTemplate.opsForHash().put(cacheKey, String.valueOf(seatNumber), String.valueOf(available));
+        }
     }
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class ReservationService {
 
-    private static final String SEAT_HOLD_KEY_PREFIX = "seats:%d:hold";
+    private static final String SEAT_HOLD_KEY_PREFIX = "concerts:%d:seats:%d:hold";
     private static final Duration SEAT_HOLD_TTL = Duration.ofMinutes(5);
 
     private final SeatRepository seatRepository;
@@ -28,8 +28,8 @@ public class ReservationService {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
-    public Long hold(Long userId, Long seatId) {
-        String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(seatId);
+    public void hold(Long userId, Long concertId, int seatNumber) {
+        String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(concertId, seatNumber);
 
 		// 키가 없으면 저장 후 true 반환 / 키가 있으면 false 반환
 		Boolean acquired = redisTemplate.opsForValue()
@@ -39,15 +39,13 @@ public class ReservationService {
             throw new BaseException(ErrorCode.SEAT_NOT_AVAILABLE);
         }
 
-        seatRepository.findByIdWithLock(seatId)
+        seatRepository.findByConcertIdAndSeatNumberWithLock(concertId, seatNumber)
                 .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
-
-        return seatId;
     }
 
     @Transactional
-    public void release(Long seatId, Long userId) {
-        String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(seatId);
+    public void release(Long concertId, int seatNumber, Long userId) {
+        String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(concertId, seatNumber);
 
         String storedUserId = redisTemplate.opsForValue().get(redisKey);
         if (storedUserId == null) {
@@ -59,13 +57,13 @@ public class ReservationService {
 
         redisTemplate.delete(redisKey);
 
-        seatRepository.findByIdWithLock(seatId)
+        seatRepository.findByConcertIdAndSeatNumberWithLock(concertId, seatNumber)
                 .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
     }
 
     @Transactional
-    public void confirm(Long seatId, Long userId) {
-        String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(seatId);
+    public void confirm(Long concertId, int seatNumber, Long userId) {
+        String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(concertId, seatNumber);
 
         String storedUserId = redisTemplate.opsForValue().get(redisKey);
         if (storedUserId == null) {
@@ -77,7 +75,7 @@ public class ReservationService {
 
         redisTemplate.delete(redisKey);
 
-        Seat seat = seatRepository.findByIdWithLock(seatId)
+        Seat seat = seatRepository.findByConcertIdAndSeatNumberWithLock(concertId, seatNumber)
                 .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
         seat.confirm();
 

--- a/podolab-api/src/main/java/com/podolab/api/seat/SeatRepository.java
+++ b/podolab-api/src/main/java/com/podolab/api/seat/SeatRepository.java
@@ -15,6 +15,6 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
 	List<Seat> findByConcertId(Long concertId);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT s FROM Seat s WHERE s.id = :id")
-	Optional<Seat> findByIdWithLock(@Param("id") Long id);
+	@Query("SELECT s FROM Seat s WHERE s.concert.id = :concertId AND s.seatNumber = :seatNumber")
+	Optional<Seat> findByConcertIdAndSeatNumberWithLock(@Param("concertId") Long concertId, @Param("seatNumber") int seatNumber);
 }

--- a/podolab-api/src/main/java/com/podolab/api/seat/SeatResponse.java
+++ b/podolab-api/src/main/java/com/podolab/api/seat/SeatResponse.java
@@ -1,13 +1,11 @@
 package com.podolab.api.seat;
 
 public record SeatResponse(
-        Long seatId,
         int seatNumber,
         boolean available
 ) {
     public static SeatResponse of(Seat seat) {
         return new SeatResponse(
-                seat.getId(),
                 seat.getSeatNumber(),
                 seat.getStatus() == SeatStatus.AVAILABLE
         );

--- a/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
+++ b/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
@@ -46,7 +46,8 @@ class ReservationServiceTest {
 
 	private static final int threadCount = 10;
 
-	private Long seatId;
+	private Long concertId;
+	private int seatNumber;
 	private List<Long> userIds;
 
 	@BeforeEach
@@ -54,11 +55,12 @@ class ReservationServiceTest {
 		Concert concert = concertRepository.save(
 			Concert.create("테스트 콘서트", LocalDate.now().plusDays(7), 100)
 		);
+		concertId = concert.getId();
+		seatNumber = 1;
 
-		Seat seat = seatRepository.save(
-			Seat.create(concert, 1, SeatStatus.AVAILABLE)
+		seatRepository.save(
+			Seat.create(concert, seatNumber, SeatStatus.AVAILABLE)
 		);
-		seatId = seat.getId();
 
 		userIds = new ArrayList<>();
 		for (int i = 0; i < threadCount; i++) {
@@ -69,7 +71,7 @@ class ReservationServiceTest {
 
 	@AfterEach
 	void tearDown() {
-		redisTemplate.delete("seats:" + seatId + ":hold");
+		redisTemplate.delete("concerts:" + concertId + ":seats:" + seatNumber + ":hold");
 		seatRepository.deleteAll();
 		concertRepository.deleteAll();
 		userRepository.deleteAll();
@@ -87,7 +89,7 @@ class ReservationServiceTest {
 			executor.execute(() -> {
 				try {
 					startLatch.await(); // startLatch가 0이 될 때까지 대기 (두 스레드 동시 출발하도록)
-					reservationService.hold(userId, seatId);
+					reservationService.hold(userId, concertId, seatNumber);
 					successCount.incrementAndGet(); // hold() 성공 시 카운트
 				} catch (Exception e) {
 					System.out.println("이미 선택된 좌석 예외: " + e.getMessage());
@@ -105,7 +107,7 @@ class ReservationServiceTest {
 		assertThat(successCount.get()).isEqualTo(1);
 
 		// Redis에 점유 키가 저장됐는지 검증
-		String redisValue = redisTemplate.opsForValue().get("seats:" + seatId + ":hold");
+		String redisValue = redisTemplate.opsForValue().get("concerts:" + concertId + ":seats:" + seatNumber + ":hold");
 		assertThat(redisValue).isNotNull();
 	}
 }

--- a/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
+++ b/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
@@ -72,6 +72,7 @@ class ReservationServiceTest {
 	@AfterEach
 	void tearDown() {
 		redisTemplate.delete("concerts:" + concertId + ":seats:" + seatNumber + ":hold");
+		redisTemplate.delete("concerts:" + concertId + ":seats");
 		seatRepository.deleteAll();
 		concertRepository.deleteAll();
 		userRepository.deleteAll();
@@ -109,5 +110,28 @@ class ReservationServiceTest {
 		// Redis에 점유 키가 저장됐는지 검증
 		String redisValue = redisTemplate.opsForValue().get("concerts:" + concertId + ":seats:" + seatNumber + ":hold");
 		assertThat(redisValue).isNotNull();
+	}
+
+	@Test
+	void hold_성공_시_캐시_false로_업데이트() {
+		String cacheKey = "concerts:" + concertId + ":seats";
+		redisTemplate.opsForHash().put(cacheKey, String.valueOf(seatNumber), "true");
+
+		reservationService.hold(userIds.get(0), concertId, seatNumber);
+
+		Object cached = redisTemplate.opsForHash().get(cacheKey, String.valueOf(seatNumber));
+		assertThat(cached).isEqualTo("false");
+	}
+
+	@Test
+	void release_시_캐시_true로_업데이트() {
+		String cacheKey = "concerts:" + concertId + ":seats";
+		redisTemplate.opsForHash().put(cacheKey, String.valueOf(seatNumber), "false");
+
+		reservationService.hold(userIds.get(0), concertId, seatNumber);
+		reservationService.release(concertId, seatNumber, userIds.get(0));
+
+		Object cached = redisTemplate.opsForHash().get(cacheKey, String.valueOf(seatNumber));
+		assertThat(cached).isEqualTo("true");
 	}
 }

--- a/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
+++ b/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
@@ -47,6 +47,7 @@ class ReservationServiceTest {
 	private static final int threadCount = 10;
 
 	private Long concertId;
+	private Long seatId;
 	private int seatNumber;
 	private List<Long> userIds;
 
@@ -58,9 +59,10 @@ class ReservationServiceTest {
 		concertId = concert.getId();
 		seatNumber = 1;
 
-		seatRepository.save(
+		Seat seat = seatRepository.save(
 			Seat.create(concert, seatNumber, SeatStatus.AVAILABLE)
 		);
+		seatId = seat.getId();
 
 		userIds = new ArrayList<>();
 		for (int i = 0; i < threadCount; i++) {
@@ -73,9 +75,9 @@ class ReservationServiceTest {
 	void tearDown() {
 		redisTemplate.delete("concerts:" + concertId + ":seats:" + seatNumber + ":hold");
 		redisTemplate.delete("concerts:" + concertId + ":seats");
-		seatRepository.deleteAll();
-		concertRepository.deleteAll();
-		userRepository.deleteAll();
+		seatRepository.deleteById(seatId);
+		concertRepository.deleteById(concertId);
+		userRepository.deleteAllById(userIds);
 	}
 
 	@Test

--- a/podolab-api/start-local.sh
+++ b/podolab-api/start-local.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
+./gradlew clean build -x test && docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build


### PR DESCRIPTION
## 🎯 작업 내용
티켓팅 오픈 시 다수의 사용자가 동시에 좌석을 조회할 경우
매 요청마다 DB 쿼리가 발생하는 문제를 Redis 캐싱으로 개선했습니다.
hold 상태가 조회 결과에 반영되지 않는 문제도 함께 해결했습니다.

<br>

## 📝 주요 변경사항
- `ConcertService` - Cache Aside 전략으로 좌석 목록 Redis 캐싱 적용
- `ReservationService` - hold/release/confirm 시 캐시 업데이트 추가
- `ReservationServiceTest` - 캐시 업데이트 검증 테스트 추가
- 좌석 식별자를 seatId에서 concertId + seatNumber 조합으로 변경

<br>

## 💭 구현 과정
### 캐시 자료구조 선택
Redis String으로 전체 좌석 목록을 JSON으로 저장하는 방법과
Redis Hash로 `field=seatNumber, value=available` 로 저장하는 방법을 고민했습니다.

String 방식은 hold 발생 시 전체 JSON을 역직렬화하고 수정한 뒤 다시 저장해야 합니다.
hold가 빈번하게 발생하는 티켓팅 상황에서는 이 비용이 문제가 될 수 있습니다.
Hash 방식은 hold 발생 시 해당 좌석 하나만 업데이트할 수 있어 Hash 방식을 선택했습니다.

### 캐시 구조
key:   concerts:{concertId}:seats
field: seatNumber
value: "true" / "false" (available 여부)

TTL은 1시간으로 설정했습니다.

### 캐싱 동기화
상태 변경(hold/release/confirm) 시 해당 좌석 field를 직접 업데이트합니다.
별도 동기화 주기 없이 상태 변경이 즉시 캐시에 반영됩니다.

### 좌석 식별자 변경
클라이언트는 seatId(DB 기본키)를 알 필요 없이
concertId + seatNumber 조합으로 좌석을 식별할 수 있습니다.
seatNumber는 콘서트 내에서 고유하므로 두 값의 조합으로 특정 좌석을 식별 가능합니다.
Redis hold 키도 `concerts:{concertId}:seats:{seatNumber}:hold` 로 변경했습니다.


<br>

## 🧪 테스트 결과

**캐싱 적용 전 (100명 동시 조회, 10초)**
<img width="903" height="686" alt="스크린샷 2026-04-10 오후 1 42 34" src="https://github.com/user-attachments/assets/5e298fe0-7759-4d86-8b62-ea564cfbd2e8" />

- TPS: 5/s
- 평균 응답 시간: 14.25s
- 최대 응답 시간: 23.23s

**캐싱 적용 후 (100명 동시 조회, 10초)**
<img width="895" height="711" alt="스크린샷 2026-04-19 오후 3 50 40" src="https://github.com/user-attachments/assets/91bcaa34-837e-4018-a2c4-fe24d3e1d305" />

- TPS: 16.2/s (3배 향상)
- 평균 응답 시간: 5.05s (65% 감소)
- 최대 응답 시간: 11.64s (50% 감소)

## 💡 개선 아이디어
- 티켓팅 오픈 전 미리 캐시를 채워두면 첫 요청부터 DB 조회 없이 처리 가능 #32

<br>

## 🔗 관련 이슈
- Close #30 