### PR TITLE
[FEAT] 티켓팅 오픈 전 좌석 캐시 워밍 스케줄러 구현

### DIFF
--- a/podolab-api/src/main/java/com/podolab/api/PodolabApiApplication.java
+++ b/podolab-api/src/main/java/com/podolab/api/PodolabApiApplication.java
@@ -3,8 +3,10 @@ package com.podolab.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class PodolabApiApplication {
 

--- a/podolab-api/src/main/java/com/podolab/api/concert/CacheWarmingScheduler.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/CacheWarmingScheduler.java
@@ -1,0 +1,62 @@
+package com.podolab.api.concert;
+
+import com.podolab.api.seat.SeatRepository;
+import com.podolab.api.seat.SeatStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CacheWarmingScheduler {
+
+    private static final String SEAT_CACHE_KEY_PREFIX = "concerts:%d:seats";
+    private static final Duration SEAT_CACHE_TTL = Duration.ofHours(1);
+
+    private final ConcertRepository concertRepository;
+    private final SeatRepository seatRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional(readOnly = true)
+    public void warmUpSeatCache() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime until = now.plusMinutes(5);
+
+        List<Concert> upcoming = concertRepository.findByOpenAtBetween(now, until);
+        if (upcoming.isEmpty()) {
+            return;
+        }
+
+        for (Concert concert : upcoming) {
+            String cacheKey = SEAT_CACHE_KEY_PREFIX.formatted(concert.getId());
+
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(cacheKey))) {
+                log.debug("seat cache already exists, skip warming: concertId={}", concert.getId());
+                continue;
+            }
+
+            Map<String, String> hashEntries = new HashMap<>();
+            seatRepository.findByConcertId(concert.getId())
+                    .forEach(seat -> hashEntries.put(
+                            String.valueOf(seat.getSeatNumber()),
+                            String.valueOf(seat.getStatus() == SeatStatus.AVAILABLE)
+                    ));
+
+            redisTemplate.opsForHash().putAll(cacheKey, hashEntries);
+            redisTemplate.expire(cacheKey, SEAT_CACHE_TTL);
+
+            log.info("seat cache warmed up: concertId={}, seats={}", concert.getId(), hashEntries.size());
+        }
+    }
+}

--- a/podolab-api/src/main/java/com/podolab/api/concert/CacheWarmingScheduler.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/CacheWarmingScheduler.java
@@ -35,6 +35,7 @@ public class CacheWarmingScheduler {
 
         List<Concert> upcoming = concertRepository.findByOpenAtBetween(now, until);
         if (upcoming.isEmpty()) {
+			log.debug("no upcoming concert found");
             return;
         }
 

--- a/podolab-api/src/main/java/com/podolab/api/concert/Concert.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/Concert.java
@@ -8,11 +8,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "concert")
+@Table(name = "concert", indexes = {
+        @Index(name = "idx_concert_open_at", columnList = "open_at")
+})
 public class Concert extends BaseEntity {
 
     @Id
@@ -28,18 +31,23 @@ public class Concert extends BaseEntity {
     @Column(nullable = false)
     private int totalSeats;
 
+    @Column(nullable = false)
+    private LocalDateTime openAt;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private Concert(String title, LocalDate concertDate, int totalSeats) {
+    private Concert(String title, LocalDate concertDate, int totalSeats, LocalDateTime openAt) {
         this.title = title;
         this.concertDate = concertDate;
         this.totalSeats = totalSeats;
+        this.openAt = openAt;
     }
 
-    public static Concert create(String title, LocalDate concertDate, int totalSeats) {
+    public static Concert create(String title, LocalDate concertDate, int totalSeats, LocalDateTime openAt) {
         return Concert.builder()
                 .title(title)
                 .concertDate(concertDate)
                 .totalSeats(totalSeats)
+                .openAt(openAt)
                 .build();
     }
 }

--- a/podolab-api/src/main/java/com/podolab/api/concert/ConcertRepository.java
+++ b/podolab-api/src/main/java/com/podolab/api/concert/ConcertRepository.java
@@ -1,6 +1,14 @@
 package com.podolab.api.concert;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ConcertRepository extends JpaRepository<Concert, Long> {
+
+    @Query("SELECT c FROM Concert c WHERE c.openAt BETWEEN :from AND :to")
+    List<Concert> findByOpenAtBetween(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }

--- a/podolab-api/src/main/java/com/podolab/api/global/config/RedisConfig.java
+++ b/podolab-api/src/main/java/com/podolab/api/global/config/RedisConfig.java
@@ -28,6 +28,8 @@ public class RedisConfig {
 		template.setConnectionFactory(redisConnectionFactory());
 		template.setKeySerializer(new StringRedisSerializer());
 		template.setValueSerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new StringRedisSerializer());
 		return template;
 	}
 }

--- a/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
@@ -30,6 +30,8 @@ public class ReservationService {
 
     @Transactional
     public void hold(Long userId, Long concertId, int seatNumber) {
+        validateSeatInCache(concertId, seatNumber);
+
         String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(concertId, seatNumber);
 
 		// 키가 없으면 저장 후 true 반환 / 키가 있으면 false 반환
@@ -39,9 +41,6 @@ public class ReservationService {
         if (Boolean.FALSE.equals(acquired)) {
             throw new BaseException(ErrorCode.SEAT_NOT_AVAILABLE);
         }
-
-        seatRepository.findByConcertIdAndSeatNumberWithLock(concertId, seatNumber)
-                .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
 
         updateSeatCache(concertId, seatNumber, false);
     }
@@ -59,10 +58,6 @@ public class ReservationService {
         }
 
         redisTemplate.delete(redisKey);
-
-        seatRepository.findByConcertIdAndSeatNumberWithLock(concertId, seatNumber)
-                .orElseThrow(() -> new BaseException(ErrorCode.SEAT_NOT_FOUND));
-
         updateSeatCache(concertId, seatNumber, true);
     }
 
@@ -91,9 +86,16 @@ public class ReservationService {
         updateSeatCache(concertId, seatNumber, false);
     }
 
+    private void validateSeatInCache(Long concertId, int seatNumber) {
+        String cacheKey = SEAT_CACHE_KEY_PREFIX.formatted(concertId);
+        if (!redisTemplate.opsForHash().hasKey(cacheKey, String.valueOf(seatNumber))) {
+            throw new BaseException(ErrorCode.SEAT_NOT_FOUND);
+        }
+    }
+
     private void updateSeatCache(Long concertId, int seatNumber, boolean available) {
         String cacheKey = SEAT_CACHE_KEY_PREFIX.formatted(concertId);
-        if (redisTemplate.hasKey(cacheKey)) {
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(cacheKey))) {
             redisTemplate.opsForHash().put(cacheKey, String.valueOf(seatNumber), String.valueOf(available));
         }
     }

--- a/podolab-api/src/main/resources/application.yml
+++ b/podolab-api/src/main/resources/application.yml
@@ -20,3 +20,8 @@ spring:
 
 server:
   port: 8080
+
+
+logging:
+  level:
+    com.podolab.api.concert.CacheWarmingScheduler: DEBUG

--- a/podolab-api/src/main/resources/dummy.sql
+++ b/podolab-api/src/main/resources/dummy.sql
@@ -3,8 +3,9 @@ DELETE FROM seat;
 DELETE FROM concert;
 
 -- 콘서트 1개 삽입
-INSERT INTO concert (title, concert_date, total_seats, created_at, updated_at)
-VALUES ('PODOLAB 콘서트 2026', '2026-08-01', 10000, NOW(), NOW());
+-- open_at: 캐시 워밍 테스트 시 NOW() + INTERVAL 4 MINUTE 로 변경하여 사용
+INSERT INTO concert (title, concert_date, total_seats, open_at, created_at, updated_at)
+VALUES ('PODOLAB 콘서트 2026', '2026-08-01', 10000, '2026-08-01 09:00:00', NOW(), NOW());
 
 -- 좌석 10000개 삽입 (seatNumber 1~10000, 전부 AVAILABLE)
 DROP PROCEDURE IF EXISTS insert_seats;

--- a/podolab-api/src/main/resources/dummy.sql
+++ b/podolab-api/src/main/resources/dummy.sql
@@ -1,6 +1,14 @@
 -- 기존 데이터 초기화
+DELETE FROM ticket;
 DELETE FROM seat;
 DELETE FROM concert;
+DELETE FROM users;
+
+-- AUTO_INCREMENT 초기화
+ALTER TABLE seat AUTO_INCREMENT = 1;
+ALTER TABLE concert AUTO_INCREMENT = 1;
+ALTER TABLE users AUTO_INCREMENT = 1;
+ALTER TABLE ticket AUTO_INCREMENT = 1;
 
 -- 콘서트 1개 삽입
 -- open_at: 캐시 워밍 테스트 시 NOW() + INTERVAL 4 MINUTE 로 변경하여 사용

--- a/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
+++ b/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
@@ -3,6 +3,7 @@ package com.podolab.api.reservation;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -54,7 +55,7 @@ class ReservationServiceTest {
 	@BeforeEach
 	void setUp() {
 		Concert concert = concertRepository.save(
-			Concert.create("테스트 콘서트", LocalDate.now().plusDays(7), 100)
+			Concert.create("테스트 콘서트", LocalDate.now().plusDays(7), 100, LocalDateTime.now().plusDays(7))
 		);
 		concertId = concert.getId();
 		seatNumber = 1;

--- a/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
+++ b/podolab-api/src/test/java/com/podolab/api/reservation/ReservationServiceTest.java
@@ -65,6 +65,9 @@ class ReservationServiceTest {
 		);
 		seatId = seat.getId();
 
+		// hold 캐시에서 좌석 존재 여부를 확인하므로 미리 세팅
+		redisTemplate.opsForHash().put("concerts:" + concertId + ":seats", String.valueOf(seatNumber), "true");
+
 		userIds = new ArrayList<>();
 		for (int i = 0; i < threadCount; i++) {
 			User user = userRepository.save(User.create("유저" + (i + 1), "user" + (i + 1) + "@test.com"));


### PR DESCRIPTION
## 🎯 작업 내용
첫 번째 조회 요청에서 cache miss가 발생해 DB를 조회하는 문제를 개선합니다.
Concert의 티켓 오픈 시간 기준으로 캐시를 미리 적재해 첫 요청부터 DB 조회 없이 처리합니다.

<br>

## 📝 주요 변경사항
- `Concert` - openAt 필드 추가
- `CacheWarmingScheduler` - openAt 5분 전 좌석 캐시 워밍 스케줄러 구현
- `RedisConfig` - Hash 직렬화 설정 추가 (setHashKeySerializer, setHashValueSerializer)
- `ReservationService` - hold/release 시 DB 조회 제거, 캐시에서 좌석 존재 여부 확인으로 변경
- `dummy.sql` - openAt 컬럼 추가

<br>

## 💭 구현 과정

### 캐시 워밍 방식 선택
수동 API 방식은 호출을 빠뜨리면 오픈 순간 첫 번째 사용자가 DB 조회로 느린 응답을 받게 됩니다.
사람 개입 없이 오픈 전 캐시 워밍을 보장할 수 있는 스케줄러 방식을 선택했습니다.

### 스케줄러 주기
1분마다 `openAt`이 5분 이내인 콘서트를 조회하는 방식을 선택했습니다.
인덱스 범위 스캔(`idx_concert_open_at`)으로 전체 스캔 없이 오픈 예정 콘서트만 조회합니다.

### 중복 워밍 방지
이미 캐시에 `concerts:{concertId}:seats`키가 있는지 확인 후, 존재한다면 스킵합니다.

### hold/release DB 조회 제거
티켓팅 흐름상 전체 좌석 조회 후 hold가 가능합니다.
전체 좌석 조회 시 캐시가 적재되므로 hold 시점엔 항상 캐시가 존재합니다.
캐시에서 좌석 존재 여부를 확인하도록 변경해 불필요한 DB 조회를 제거했습니다.

<br>

## 🧠 배운 점 / 개선 아이디어
- `@Scheduled` cron 표현식은 고정 시간만 지정 가능해 콘서트마다 다른 오픈 시간에 동적으로 대응하려면 별도 처리가 필요함

<br>

## 🧪 테스트 결과
### 캐시 워밍 전 (cache miss)
캐시가 없는 상태에서 첫 번째 좌석 조회 시 DB 쿼리 발생

<img width="960" height="1113" alt="스크린샷 2026-04-26 오후 3 12 55" src="https://github.com/user-attachments/assets/768e688b-0581-4b6c-9163-7960e2097cf6" />

<br>
<img width="803" height="310" alt="image" src="https://github.com/user-attachments/assets/efc8bc2d-e930-4af1-950e-d51715b326e5" />


<br>

### 캐시 워밍 후 (cache hit)
openAt 5분 전 스케줄러가 실행되어 캐시가 미리 채워진 상태

<br>

<img width="946" height="422" alt="스크린샷 2026-04-26 오후 3 15 33" src="https://github.com/user-attachments/assets/aa93221b-f3c1-46ed-8eb5-13ef74f84350" />

<br>

<img width="794" height="33" alt="스크린샷 2026-04-26 오후 3 13 31" src="https://github.com/user-attachments/assets/d96a0d3c-d315-452d-86ad-f61dcfe42562" />

<br>

<img width="909" height="222" alt="image" src="https://github.com/user-attachments/assets/b2035ee3-c5cc-4884-bafa-3cf5f9a1a181" />

<br>

<img width="830" height="93" alt="image" src="https://github.com/user-attachments/assets/ba7e0017-7f2e-4846-80b8-3e80e7493824" />

<br>

캐시가 채워진 상태에서 첫 번째 요청부터 DB 조회 없이 처리

<br>

<img width="959" height="1122" alt="스크린샷 2026-04-26 오후 3 15 49" src="https://github.com/user-attachments/assets/62292314-17e3-4d25-ac90-5af4ab10d722" />

### 응답 시간 비교
| 상황 | 응답 시간 |
|------|---------|
| 캐시 없을 때 첫 요청 | 945ms |
| 캐시 워밍 후 첫 요청 | 69ms |

캐시 워밍 없이는 첫 번째 요청에서 DB 조회가 발생해 945ms가 걸렸지만,
워밍으로 미리 캐시를 채워두면 첫 요청부터 69ms로 처리됩니다. **약 13배 개선**

<br>

## 🔗 관련 이슈
- Close #32 
