### PR TITLE
[REFACTOR] hold, release 메서드 불필요한 @Transactional 제거

### DIFF
--- a/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
+++ b/podolab-api/src/main/java/com/podolab/api/reservation/ReservationService.java
@@ -28,7 +28,6 @@ public class ReservationService {
     private final TicketRepository ticketRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
-    @Transactional
     public void hold(Long userId, Long concertId, int seatNumber) {
         validateSeatInCache(concertId, seatNumber);
 
@@ -45,7 +44,6 @@ public class ReservationService {
         updateSeatCache(concertId, seatNumber, false);
     }
 
-    @Transactional
     public void release(Long concertId, int seatNumber, Long userId) {
         String redisKey = SEAT_HOLD_KEY_PREFIX.formatted(concertId, seatNumber);
 


### PR DESCRIPTION
<!-- PR 제목 예시: [FEAT] 좌석 예약 API 구현 -->

## 🎯 작업 내용
> hold, release 메서드의 불필요한 @Transactional 제거

<!-- 예시: 좌석 예약 기본 API 구현 -->

<br>

## 📝 주요 변경사항

- `hold()` @Transactional 제거
- `release()` @Transactional 제거

<br>

## 💭 구현 과정 / 트러블슈팅

두 메서드는 Redis 작업만 수행하며 DB 접근이 없습니다.
@Transactional이 붙으면 메서드 호출마다 커넥션 풀에서 커넥션을 점유하고,
메서드가 끝나야 반납하기 때문에 트래픽이 몰릴 경우 커넥션 풀 고갈로 이어질 수 있습니다.
`confirm()`은 Seat, User, Ticket DB 작업이 하나의 트랜잭션으로 묶여야 하므로 유지했습니다. 

<br>

## 🧠 배운 점 / 개선 아이디어
@Transactional은 DB 작업이 없는 메서드에 붙여도 커넥션을 점유합니다.

<!-- 
예시:
- @Transactional의 동작 방식과 격리 수준에 대해 학습
- 추후 Kafka를 도입해 비동기 처리 개선 예정
-->

<br>

## 🧪 테스트 결과
> 기능 검증 내용과 실행 결과 캡처 또는 로그 첨부

<!-- 
- POST /api/reservations (정상 예약) → 200 OK
- POST /api/reservations (중복 예약) → 400 Bad Request
-->

<br>

## 📸 스크린샷 / 로그 (선택사항)
<!-- Postman 캡처, API 응답 로그 등 -->

<br>

## 🔗 관련 이슈
- Close #37 


<br>

## 📚 참고 자료 (선택사항)
<!-- 이번 작업에서 참고한 자료 -->